### PR TITLE
Updated conda requirements for boost

### DIFF
--- a/conda-recipe/pQCTIO/meta.yaml
+++ b/conda-recipe/pQCTIO/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - ninja
     - gtest
   run:
-    - boost >=1.57
+    - boost >=1.57,<=1.67
 
 about:
   home: https://github.com/Numerics88/pQCTIO


### PR DESCRIPTION
Just making the conda build and run requirements consistent for aimio, n88util and pqctio.